### PR TITLE
[Feat/#18] 파일 업로드 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
+	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -43,9 +43,14 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    // Jackson
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.19.2')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 }
 

--- a/src/main/java/pproject/once_upon_a_time/auth/config/SecurityConfig.java
+++ b/src/main/java/pproject/once_upon_a_time/auth/config/SecurityConfig.java
@@ -9,13 +9,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-@EnableWebSecurity(debug = false)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
-//    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -24,22 +25,33 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        // 공개 접근 허용
                         .requestMatchers(
                                 "/v3/api-docs/**",
-                                "/swagger-ui/**", 
+                                "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/api/auth/**"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // 프리플라이트 허용
-                        
-                        // 인증 필요 (좋아요, 저장 기능만)
-                        .anyRequest().permitAll()  // 나머지는 모두 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .anyRequest().permitAll()
                 )
-//                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(f -> f.sameOrigin()));
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("*"); // 정확한 origin 넣는게 보안상 안전
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
     }
 }

--- a/src/main/java/pproject/once_upon_a_time/config/SwaggerConfig.java
+++ b/src/main/java/pproject/once_upon_a_time/config/SwaggerConfig.java
@@ -1,37 +1,43 @@
 package pproject.once_upon_a_time.config;
 
-
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
-import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import pproject.once_upon_a_time.global.response.ExceptionDto;
 
 @Configuration
+@SecurityScheme(
+        name = "JWT TOKEN",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
         Info info = new Info()
-                .title("옛날옛적에")
-                .description("개발 중인 백엔드 API 명세입니다.")
+                .title("Once Upon A Time API")
+                .description("개발 중인 백엔드 REST API 명세")
                 .version("v1.0.0");
 
         String jwtSchemeName = "JWT TOKEN";
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
         Components components = new Components()
-                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                .addSecuritySchemes(jwtSchemeName, new io.swagger.v3.oas.models.security.SecurityScheme()
                         .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP)
+                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));
 
@@ -62,33 +68,13 @@ public class SwaggerConfig {
                     pathItem.readOperations().forEach(op -> {
                         op.getResponses()
                                 .addApiResponse("400", new io.swagger.v3.oas.models.responses.ApiResponse()
-                                        .description("요청 파라미터 오류").content(errorContent))
+                                        .description("잘못된 파라미터 오류").content(errorContent))
                                 .addApiResponse("502", new io.swagger.v3.oas.models.responses.ApiResponse()
-                                        .description("외부 관광 API 오류").content(errorContent))
+                                        .description("외부 연동 API 오류").content(errorContent))
                                 .addApiResponse("500", new io.swagger.v3.oas.models.responses.ApiResponse()
                                         .description("서버 오류").content(errorContent));
                     })
             );
         };
     }
-
-
-    // Auth(카카오) 그룹
-    @Bean
-    GroupedOpenApi authGroup(@Qualifier("commonErrorResponses") OpenApiCustomizer commonErrorResponses) {
-        return GroupedOpenApi.builder()
-                .group("Auth")
-                .pathsToMatch("/api/auth/**")
-                .addOpenApiCustomizer(commonErrorResponses)
-                .build();
-    }
-
-
-     @Bean
-     GroupedOpenApi allApis() {
-         return GroupedOpenApi.builder()
-                 .group("All APIs")
-                 .pathsToMatch("/**")
-                 .build();
-     }
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/story/domain/Story.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/domain/Story.java
@@ -37,6 +37,9 @@ public class Story {
     @Column(name = "tags", length = 200)
     private String tags; // 태그
 
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl; // 썸네일 이미지 URL
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt; // 생성 요청 시각

--- a/src/main/java/pproject/once_upon_a_time/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/pproject/once_upon_a_time/global/exception/GlobalExceptionHandler.java
@@ -6,14 +6,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import pproject.once_upon_a_time.global.response.ApiResponse;
+import pproject.once_upon_a_time.global.response.ApiResult;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e, HttpServletRequest request) {
-        ApiResponse<Void> response = ApiResponse.fail(e, request.getRequestURI());
+    public ResponseEntity<ApiResult<Void>> handleCustomException(CustomException e, HttpServletRequest request) {
+        ApiResult<Void> response = ApiResult.fail(e, request.getRequestURI());
         return ResponseEntity
                 .status(response.httpStatus())
                 .body(response);

--- a/src/main/java/pproject/once_upon_a_time/global/response/ApiResult.java
+++ b/src/main/java/pproject/once_upon_a_time/global/response/ApiResult.java
@@ -5,22 +5,22 @@ import io.micrometer.common.lang.Nullable;
 import org.springframework.http.HttpStatus;
 import pproject.once_upon_a_time.global.exception.CustomException;
 
-public record ApiResponse<T>(
+public record ApiResult<T>(
         @JsonIgnore HttpStatus httpStatus,
         boolean success,
         @Nullable T data,
         @Nullable ExceptionDto error
 ) {
-    public static <T> ApiResponse<T> ok(@Nullable final T data) {
-        return new ApiResponse<>(HttpStatus.OK, true, data, null);
+    public static <T> ApiResult<T> ok(@Nullable final T data) {
+        return new ApiResult<>(HttpStatus.OK, true, data, null);
     }
 
-    public static <T> ApiResponse<T> created(@Nullable final T data) {
-        return new ApiResponse<>(HttpStatus.CREATED, true, data, null);
+    public static <T> ApiResult<T> created(@Nullable final T data) {
+        return new ApiResult<>(HttpStatus.CREATED, true, data, null);
     }
 
-    public static <T> ApiResponse<T> fail(final CustomException e, final String path) {
-        return new ApiResponse<>(
+    public static <T> ApiResult<T> fail(final CustomException e, final String path) {
+        return new ApiResult<>(
                 e.getErrorCode().getHttpStatus(),
                 false,
                 null,

--- a/src/main/java/pproject/once_upon_a_time/infrastructure/SupabaseStorageService.java
+++ b/src/main/java/pproject/once_upon_a_time/infrastructure/SupabaseStorageService.java
@@ -1,0 +1,109 @@
+package pproject.once_upon_a_time.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SupabaseStorageService {
+
+    @Value("${supabase.url}")
+    private String supabaseUrl;
+
+    @Value("${supabase.service-key}")
+    private String serviceKey;
+
+    @Value("${supabase.buckets.image}")
+    private String imageBucket;
+
+    @Value("${supabase.buckets.audio}")
+    private String audioBucket;
+
+    @Value("${supabase.buckets.character}")
+    private String characterBucket;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private final List<String> imageTypes = List.of("image/png", "image/jpeg", "image/jpg", "image/webp");
+    // character는 audio와 동일한 MIME 허용 목록을 사용
+    private final List<String> audioTypes = List.of("audio/mpeg", "audio/wav", "audio/mp4", "audio/ogg");
+
+    /**
+     * 버킷 타입별 업로드
+     */
+    public String uploadFile(MultipartFile file, FileType type) throws IOException {
+        validateMimeType(file, type);
+
+        String bucket = switch (type) {
+            case IMAGE -> imageBucket;
+            case AUDIO -> audioBucket;
+            case CHARACTER -> characterBucket;
+        };
+
+        return uploadToBucket(file, bucket);
+    }
+
+    private void validateMimeType(MultipartFile file, FileType type) {
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            throw new IllegalArgumentException("파일의 Content-Type을 확인할 수 없습니다.");
+        }
+
+        boolean allowed = switch (type) {
+            case IMAGE -> imageTypes.contains(contentType);
+            case AUDIO, CHARACTER -> audioTypes.contains(contentType);
+        };
+
+        if (!allowed) {
+            throw new IllegalArgumentException("허용되지 않은 " + type.name().toLowerCase() + " MIME 타입입니다: " + contentType);
+        }
+    }
+
+    private String uploadToBucket(MultipartFile file, String bucket) throws IOException {
+        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+
+        // Supabase 업로드 endpoint
+        String uploadUrl = supabaseUrl + "/storage/v1/object/" + bucket + "/" + fileName;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("apikey", serviceKey);
+        headers.set("Authorization", "Bearer " + serviceKey);
+
+        MediaType mediaType = file.getContentType() != null
+                ? MediaType.parseMediaType(file.getContentType())
+                : MediaType.APPLICATION_OCTET_STREAM;
+        headers.setContentType(mediaType);
+
+        HttpEntity<byte[]> request = new HttpEntity<>(file.getBytes(), headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                uploadUrl,
+                HttpMethod.POST,
+                request,
+                String.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new RuntimeException("Supabase 업로드 실패: " + response.getBody());
+        }
+
+        // Public URL 반환
+        return supabaseUrl + "/storage/v1/object/public/" + bucket + "/" + fileName;
+    }
+
+    public enum FileType {
+        IMAGE, AUDIO, CHARACTER
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/infrastructure/UploadController.java
+++ b/src/main/java/pproject/once_upon_a_time/infrastructure/UploadController.java
@@ -1,0 +1,75 @@
+package pproject.once_upon_a_time.infrastructure;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import pproject.once_upon_a_time.global.response.ApiResult;
+import pproject.once_upon_a_time.global.response.ExceptionDto;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/upload")
+@Tag(name = "Upload", description = "Supabase 스토리지 업로드 API")
+public class UploadController {
+
+    private final SupabaseStorageService storageService;
+
+    @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "이미지 업로드", description = "이미지 파일을 Supabase 이미지 버킷에 업로드합니다.")
+    @ApiResponse(responseCode = "200", description = "업로드 성공",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UploadUrlApiResult.class)))
+    public ResponseEntity<ApiResult<UploadUrlResponse>> uploadImage(@RequestParam("file") MultipartFile file) throws IOException {
+        String url = storageService.uploadFile(file, SupabaseStorageService.FileType.IMAGE);
+        var body = ApiResult.ok(new UploadUrlResponse(url));
+        return ResponseEntity.status(body.httpStatus()).body(body);
+    }
+
+    @PostMapping(value = "/audio", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "오디오 업로드", description = "오디오 파일을 Supabase 오디오 버킷에 업로드합니다.")
+    @ApiResponse(responseCode = "200", description = "업로드 성공",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UploadUrlApiResult.class)))
+    public ResponseEntity<ApiResult<UploadUrlResponse>> uploadAudio(@RequestParam("file") MultipartFile file) throws IOException {
+        String url = storageService.uploadFile(file, SupabaseStorageService.FileType.AUDIO);
+        var body = ApiResult.ok(new UploadUrlResponse(url));
+        return ResponseEntity.status(body.httpStatus()).body(body);
+    }
+
+    @PostMapping(value = "/character", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "캐릭터 오디오 업로드", description = "캐릭터용 오디오 파일을 Supabase 캐릭터 버킷에 업로드합니다.")
+    @ApiResponse(responseCode = "200", description = "업로드 성공",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UploadUrlApiResult.class)))
+    public ResponseEntity<ApiResult<UploadUrlResponse>> uploadCharacter(@RequestParam("file") MultipartFile file) throws IOException {
+        String url = storageService.uploadFile(file, SupabaseStorageService.FileType.CHARACTER);
+        var body = ApiResult.ok(new UploadUrlResponse(url));
+        return ResponseEntity.status(body.httpStatus()).body(body);
+    }
+
+    /** 업로드된 파일의 공개 URL을 담는 DTO. */
+    @Schema(name = "UploadUrlResponse", description = "업로드된 파일의 퍼블릭 URL")
+    public record UploadUrlResponse(String url) {}
+
+    /** Swagger에서 ApiResult<UploadUrlResponse> 구조를 보여주기 위한 샘플 스키마. */
+    @Schema(name = "UploadUrlApiResult")
+    public static class UploadUrlApiResult {
+        @Schema(description = "요청 성공 여부", example = "true")
+        public boolean success = true;
+
+        @Schema(description = "업로드된 파일 정보")
+        public UploadUrlResponse data = new UploadUrlResponse("https://.../path/to/file");
+
+        @Schema(description = "에러 정보(성공 시 null)")
+        public ExceptionDto error;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,11 @@ spring:
 
 server:
   port: 8080
+
+supabase:
+  url: ${SUPABASE_URL}
+  service-key: ${SUPABASE_SERVICE_KEY}
+
+  buckets:
+    image: ${SUPABASE_IMAGE_BUCKET}
+    audio: ${SUPABASE_AUDIO_BUCKET}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,6 +18,11 @@ spring:
         format_sql: true
     show-sql: true
 
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+
 server:
   port: 8080
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,3 +28,4 @@ supabase:
   buckets:
     image: ${SUPABASE_IMAGE_BUCKET}
     audio: ${SUPABASE_AUDIO_BUCKET}
+    character: ${SUPABASE_CHARACTER_BUCKET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,6 +18,11 @@ spring:
         format_sql: false
     show-sql: false
 
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+
 server:
   port: ${SERVER_PORT}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,11 @@ spring:
 
 server:
   port: ${SERVER_PORT:60003}
+
+supabase:
+  url: ${SUPABASE_URL}
+  service-key: ${SUPABASE_SERVICE_KEY}
+
+  buckets:
+    image: ${SUPABASE_IMAGE_BUCKET}
+    audio: ${SUPABASE_AUDIO_BUCKET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,7 +19,7 @@ spring:
     show-sql: false
 
 server:
-  port: ${SERVER_PORT:60003}
+  port: ${SERVER_PORT}
 
 supabase:
   url: ${SUPABASE_URL}
@@ -28,3 +28,4 @@ supabase:
   buckets:
     image: ${SUPABASE_IMAGE_BUCKET}
     audio: ${SUPABASE_AUDIO_BUCKET}
+    character: ${SUPABASE_CHARACTER_BUCKET}


### PR DESCRIPTION

## 🚀 Related Issue
- #18
## 📄 Description
- Supabase 스토리지 연동
SupabaseStorageService: 이미지/오디오/캐릭터 버킷 주입, MIME 검증(이미지/오디오 동일 목록), 업로드 후 public URL 반환.
FileType에 CHARACTER 추가, 캐릭터 버킷은 오디오와 동일 MIME 허용.

⚠ 한 버킷당 50MB 제한. 
목적에 맞는 이미지, 오디오(오디오북), 캐릭터 버킷 사용 필요!!

- 업로드 API
UploadController: /upload/image, /upload/audio, /upload/character (multipart/form-data).
응답은 ApiResult<UploadUrlResponse>로 URL만 내려주며 Swagger 메타데이터/샘플 스키마 포함.

- 공통 응답 리팩터링
ApiResponse → ApiResult로 네이밍 변경, 글로벌 예외 핸들러 등 전역 사용처 반영.

- 설정 추가
dev/prod yml에 supabase.url, service-key, buckets.image/audio/character 환경변수 매핑 추가. 새 env SUPABASE_CHARACTER_BUCKET 필요.

- Swagger/Jackson & 버전 조정
springdoc-openapi 2.8.9로 상향, Jackson BOM/코어 의존성 명시.
Spring Boot 3.5.6 → 3.5.3으로 낮춤: springdoc와의 호환 이슈(스웨거 500/Fetch error) 해결 목적.

## ✅ Test Checklist
- [x] 스토리지 업로드 확인

## 📸 Screenshots
<img width="1415" height="1220" alt="image" src="https://github.com/user-attachments/assets/6c35d89f-2b36-4c15-ab9f-addffa9e0e30" />
<img width="565" height="666" alt="image" src="https://github.com/user-attachments/assets/0bea302a-186a-478a-85e8-0dbfcfa10391" />
