### PR TITLE
[Refactor] 오디오북 재생, 리스트 조회 api 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .env
 devdb.mv.db
 devdb.lock.db
+AGENTS.md
 
 ### STS ###
 .apt_generated

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/controller/AudioBookController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/controller/AudioBookController.java
@@ -56,7 +56,16 @@ public class AudioBookController {
 
         @Schema(description = "응답 데이터")
         public AudioBookResponseDto data = new AudioBookResponseDto(
-                java.util.List.of(new AudioBookResponseDto.Item(1L, "동화 제목"))
+                java.util.List.of(new AudioBookResponseDto.Item(
+                        1L,
+                        "동화 제목",
+                        "동화 제목",
+                        "테마",
+                        "분위기",
+                        "https://example.com/thumbnail.jpg",
+                        "캐릭터 이름",
+                        600
+                ))
         );
 
         @Schema(description = "에러 정보(성공 시 null)")

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookResponseDto.java
@@ -29,5 +29,23 @@ public class AudioBookResponseDto {
 
         @Schema(description = "오디오북 이름(스토리 제목)", example = "헨젤과 그레텔")
         private String audiobookName;
+
+        @Schema(description = "동화 제목", example = "숲속의 용감한 토끼")
+        private String storyTitle;
+
+        @Schema(description = "동화 테마", example = "용기")
+        private String theme;
+
+        @Schema(description = "동화 분위기", example = "따뜻하고 서정적")
+        private String vibe;
+
+        @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
+        private String thumbnailUrl;
+
+        @Schema(description = "캐릭터 이름", example = "루비")
+        private String characterName;
+
+        @Schema(description = "오디오북 길이(초)", example = "600")
+        private Integer duration;
     }
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/PlaybackInfoResponse.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/PlaybackInfoResponse.java
@@ -28,4 +28,22 @@ public class PlaybackInfoResponse {
 
     @Schema(description = "재생 상태", example = "PLAYING")
     private PlaybackStatus status;
+
+    @Schema(description = "오디오북 길이(초)", example = "600")
+    private Integer duration;
+
+    @Schema(description = "동화 제목", example = "숲속의 용감한 토끼")
+    private String storyTitle;
+
+    @Schema(description = "동화 테마", example = "용기")
+    private String theme;
+
+    @Schema(description = "동화 분위기", example = "따뜻하고 서정적")
+    private String vibe;
+
+    @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
+    private String thumbnailUrl;
+
+    @Schema(description = "캐릭터 이름", example = "루비")
+    private String characterName;
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/repository/AudioBookRepository.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/repository/AudioBookRepository.java
@@ -13,10 +13,17 @@ public interface AudioBookRepository extends JpaRepository<AudioBook, Long> {
     @Query("""
             select new pproject.once_upon_a_time.domain.audiobook.dto.AudioBookResponseDto$Item(
                 a.id,
-                s.title
+                s.title,
+                s.title,
+                s.theme,
+                s.vibe,
+                s.thumbnailUrl,
+                c.characterName,
+                a.duration
             )
             from AudioBook a
             join a.story s
+            join a.character c
             join a.member m
             where m.id = :memberId
             """)

--- a/src/main/java/pproject/once_upon_a_time/domain/playback/controller/PlaybackController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/playback/controller/PlaybackController.java
@@ -38,13 +38,13 @@ public class PlaybackController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(
             summary = "재생 정보 조회",
-            description = "DB 재생 정보를 조회하고 Redis 값이 있으면 우선 적용해 반환합니다.",
+            description = "DB 재생 정보를 조회하고 Redis 값이 있으면 우선 적용해 반환합니다. 동화/캐릭터 메타정보(제목, 테마, 분위기, 썸네일, 주인공 이름) 포함.",
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PlaybackInfoResponse.class))),
-            @ApiResponse(responseCode = "404", description = "재생 정보 없음"),
+            @ApiResponse(responseCode = "404", description = "재생 정보 없음 / 오디오북 또는 관련 동화/캐릭터 없음"),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     public ResponseEntity<ApiResult<PlaybackInfoResponse>> getPlayback(

--- a/src/main/java/pproject/once_upon_a_time/domain/playback/service/PlaybackService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/playback/service/PlaybackService.java
@@ -11,11 +11,13 @@ import pproject.once_upon_a_time.domain.audiobook.dto.PlaybackInfoResponse;
 import pproject.once_upon_a_time.domain.audiobook.dto.PlaybackProgressRequest;
 import pproject.once_upon_a_time.domain.audiobook.dto.PlaybackStartResponse;
 import pproject.once_upon_a_time.domain.audiobook.repository.AudioBookRepository;
+import pproject.once_upon_a_time.domain.character.domain.Character;
 import pproject.once_upon_a_time.domain.member.domain.Member;
 import pproject.once_upon_a_time.domain.playback.domain.AudioBookPlayback;
 import pproject.once_upon_a_time.domain.playback.domain.PlaybackStatus;
 import pproject.once_upon_a_time.domain.playback.infrastructure.PlaybackRedisRepository;
 import pproject.once_upon_a_time.domain.playback.repository.AudioBookPlaybackRepository;
+import pproject.once_upon_a_time.domain.story.domain.Story;
 import pproject.once_upon_a_time.global.exception.CustomException;
 import pproject.once_upon_a_time.global.exception.ErrorCode;
 
@@ -42,6 +44,16 @@ public class PlaybackService {
         AudioBookPlayback playback = playbackRepository.findByAudioBook_IdAndMemberId_Id(audiobookId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAYBACK_NOT_FOUND));
 
+        Story story = audioBook.getStory();
+        if (story == null) {
+            throw new CustomException(ErrorCode.AUDIOBOOK_STORY_NOT_FOUND);
+        }
+
+        Character character = audioBook.getCharacter();
+        if (character == null) {
+            throw new CustomException(ErrorCode.AUDIOBOOK_CHARACTER_NOT_FOUND);
+        }
+
         Integer lastPosition = playback.getLastPosition();
         PlaybackStatus status = playback.getStatus();
 
@@ -65,9 +77,15 @@ public class PlaybackService {
         return PlaybackInfoResponse.builder()
                 .playbackId(playback.getId())
                 .audiobookId(audiobookId)
+                .duration(audioBook.getDuration())
                 .lastPosition(lastPosition)
                 .progressRate(progressRate)
                 .status(status)
+                .storyTitle(story.getTitle())
+                .theme(story.getTheme())
+                .vibe(story.getVibe())
+                .thumbnailUrl(story.getThumbnailUrl())
+                .characterName(character.getCharacterName())
                 .build();
     }
 

--- a/src/main/java/pproject/once_upon_a_time/global/common/StringListConverter.java
+++ b/src/main/java/pproject/once_upon_a_time/global/common/StringListConverter.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import lombok.SneakyThrows;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -14,23 +15,33 @@ import java.util.List;
 @Converter
 public class StringListConverter implements AttributeConverter<List<String>, String> {
 
+    private static final Logger log = LoggerFactory.getLogger(StringListConverter.class);
+
     private final ObjectMapper mapper = new ObjectMapper();
 
-    @SneakyThrows
     @Override
     public String convertToDatabaseColumn(List<String> attribute) {
         if (attribute == null || attribute.isEmpty()) {
             return null;
         }
-        return mapper.writeValueAsString(attribute);
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            log.warn("List<String> to JSON 변환 실패, null 반환. attribute={}", attribute, e);
+            return null;
+        }
     }
 
-    @SneakyThrows
     @Override
     public List<String> convertToEntityAttribute(String dbData) {
         if (dbData == null || dbData.isBlank()) {
             return List.of();
         }
-        return mapper.readValue(dbData, new TypeReference<>() {});
+        try {
+            return mapper.readValue(dbData, new TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("JSON to List<String> 파싱 실패, 빈 리스트 반환. raw={}", dbData, e);
+            return List.of();
+        }
     }
 }

--- a/src/main/java/pproject/once_upon_a_time/global/exception/ErrorCode.java
+++ b/src/main/java/pproject/once_upon_a_time/global/exception/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
     STORY_NOT_FOUND(404_005, HttpStatus.NOT_FOUND, "동화를 찾을 수 없습니다."),
     AUDIOBOOK_NOT_FOUND(404_006, HttpStatus.NOT_FOUND, "오디오북을 찾을 수 없습니다."),
     PLAYBACK_NOT_FOUND(404_007, HttpStatus.NOT_FOUND, "재생 정보를 찾을 수 없습니다."),
+    AUDIOBOOK_STORY_NOT_FOUND(404_008, HttpStatus.NOT_FOUND, "해당 오디오북에 연결된 동화를 찾을 수 없습니다."),
+    AUDIOBOOK_CHARACTER_NOT_FOUND(404_009, HttpStatus.NOT_FOUND, "해당 오디오북에 연결된 캐릭터를 찾을 수 없습니다."),
 
 
     // ========================


### PR DESCRIPTION

## 🚀 Related Issue
- #57

## 📄 Description
피그마 수정사항에 따른 api 수정
 - GET /api/v1/audiobooks/{audiobookId}/playback: 응답 DTO에 duration 추가, 서비스에서 오디오북 길이를 포함해 반환하도록 수정.
  - GET /api/v1/audiobooks: 리스트 DTO 항목에 동화 제목/테마/분위기/썸네일/캐릭터 이름/duration 필드 추가, 레포지토리 쿼리(스토리·캐릭터 조인) 및 Swagger 예제 갱신.

## ✅ Test Checklist
- [x] 테스트

## 📸 Screenshots
<img width="1421" height="1192" alt="image" src="https://github.com/user-attachments/assets/b1f17578-3646-4633-8c23-1c182930f339" />
<img width="1412" height="1046" alt="image" src="https://github.com/user-attachments/assets/f7525401-60f3-4efb-a905-ff8915793467" />
