### PR TITLE
[Feat] 이미지 생성 파이썬 childprocess 실행 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ devdb.lock.db
 devdb.trace.db
 AGENTS.md
 mock_generator.py
+content/**
 
 ### STS ###
 .apt_generated

--- a/src/main/java/pproject/once_upon_a_time/domain/story/controller/StoryController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/controller/StoryController.java
@@ -5,10 +5,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Parameter;
+import pproject.once_upon_a_time.auth.annotation.LoginUser;
 import pproject.once_upon_a_time.domain.story.dto.StoryDetailResponseDto;
 import pproject.once_upon_a_time.domain.story.dto.StoryListResponseDto;
 import pproject.once_upon_a_time.domain.story.dto.UserRequestDto;
+import pproject.once_upon_a_time.domain.story.dto.StoryThumbnailResponseDto;
 import pproject.once_upon_a_time.domain.story.service.StoryService;
+import pproject.once_upon_a_time.domain.story.service.StoryThumbnailService;
+import pproject.once_upon_a_time.domain.member.domain.Member;
 import pproject.once_upon_a_time.global.response.ApiResult;
 
 import java.net.URI;
@@ -20,6 +25,7 @@ import java.util.List;
 public class StoryController {
 
     private final StoryService storyService;
+    private final StoryThumbnailService storyThumbnailService;
 
     @PostMapping
     public ResponseEntity<StoryDetailResponseDto> createStory(
@@ -40,5 +46,14 @@ public class StoryController {
     public ResponseEntity<ApiResult<StoryDetailResponseDto>> getStoryDetail(
             @PathVariable Long storyId) {
         return ResponseEntity.ok(ApiResult.ok(storyService.getStoryDetail(storyId)));
+    }
+
+    @PostMapping("/{storyId}/thumbnail")
+    public ResponseEntity<ApiResult<StoryThumbnailResponseDto>> generateThumbnail(
+            @PathVariable Long storyId,
+            @Parameter(hidden = true) @LoginUser Member member) {
+        String thumbnailUrl = storyThumbnailService.generateThumbnail(storyId, member);
+        ApiResult<StoryThumbnailResponseDto> body = ApiResult.ok(new StoryThumbnailResponseDto(thumbnailUrl));
+        return ResponseEntity.status(body.httpStatus()).body(body);
     }
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/story/dto/StoryThumbnailResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/dto/StoryThumbnailResponseDto.java
@@ -1,0 +1,4 @@
+package pproject.once_upon_a_time.domain.story.dto;
+
+public record StoryThumbnailResponseDto(String thumbnailUrl) {
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/story/service/StoryThumbnailService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/service/StoryThumbnailService.java
@@ -1,0 +1,116 @@
+package pproject.once_upon_a_time.domain.story.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pproject.once_upon_a_time.domain.member.domain.Member;
+import pproject.once_upon_a_time.domain.story.domain.GenerationStatus;
+import pproject.once_upon_a_time.domain.story.domain.Story;
+import pproject.once_upon_a_time.domain.story.repository.StoryRepository;
+import pproject.once_upon_a_time.global.exception.CustomException;
+import pproject.once_upon_a_time.global.exception.ErrorCode;
+import pproject.once_upon_a_time.infrastructure.PythonImageGenRunner;
+import pproject.once_upon_a_time.infrastructure.SupabaseStorageService;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StoryThumbnailService {
+
+    private final StoryRepository storyRepository;
+    private final PythonImageGenRunner pythonImageGenRunner;
+    private final SupabaseStorageService supabaseStorageService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public String generateThumbnail(Long storyId, Member loginMember) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+
+        validateOwner(story, loginMember);
+        validateGenerationStatus(story);
+
+        if (story.getThumbnailUrl() != null && !story.getThumbnailUrl().isBlank()) {
+            return story.getThumbnailUrl();
+        }
+
+        String inputJson = buildPythonInput(story);
+        String stdout = pythonImageGenRunner.run(inputJson);
+
+        String imageBase64 = parseImageBase64(stdout);
+        byte[] imageBytes = decodeBase64(imageBase64);
+
+        String objectName = "stories/" + story.getId() + "/thumbnail.png";
+        String uploadedUrl = uploadImage(imageBytes, objectName);
+
+        story.updateThumbnailUrl(uploadedUrl);
+        return uploadedUrl;
+    }
+
+    private void validateOwner(Story story, Member loginMember) {
+        if (!Objects.equals(story.getMember().getId(), loginMember.getId())) {
+            throw new CustomException(ErrorCode.STORY_OWNER_MISMATCH);
+        }
+    }
+
+    private void validateGenerationStatus(Story story) {
+        if (story.getGenerationStatus() != GenerationStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.STORY_THUMBNAIL_NOT_ALLOWED,
+                    "썸네일은 COMPLETED 상태에서만 생성할 수 있습니다.");
+        }
+    }
+
+    private String buildPythonInput(Story story) {
+        try {
+            var root = objectMapper.createObjectNode();
+            root.put("title", story.getTitle());
+            root.put("content", story.getContent());
+            root.putPOJO("keywords", story.getKeywords());
+            return objectMapper.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 입력 JSON 생성 실패: " + e.getMessage());
+        }
+    }
+
+    private String parseImageBase64(String stdout) {
+        try {
+            JsonNode root = objectMapper.readTree(stdout);
+            boolean success = root.path("success").asBoolean(false);
+            if (!success) {
+                String error = root.path("error").asText("파이썬 처리에 실패했습니다.");
+                throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, error);
+            }
+            String imageBase64 = root.path("data").path("image_base64").asText(null);
+            if (imageBase64 == null || imageBase64.isBlank()) {
+                throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 결과에 image_base64가 없습니다.");
+            }
+            return imageBase64;
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력 파싱 실패: " + e.getMessage());
+        }
+    }
+
+    private byte[] decodeBase64(String imageBase64) {
+        try {
+            return Base64.getDecoder().decode(imageBase64.getBytes(StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "image_base64 디코딩 실패: " + e.getMessage());
+        }
+    }
+
+    private String uploadImage(byte[] imageBytes, String objectName) {
+        try {
+            return supabaseStorageService.uploadImageBytes(imageBytes, objectName);
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.SUPABASE_UPLOAD_FAILED, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/global/exception/ErrorCode.java
+++ b/src/main/java/pproject/once_upon_a_time/global/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     // ========================
     FORBIDDEN(403_000, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
     ACCESS_DENY(403_001, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+    STORY_OWNER_MISMATCH(403_002, HttpStatus.FORBIDDEN, "동화 소유자가 아닙니다."),
 
 
     // ========================
@@ -67,6 +68,7 @@ public enum ErrorCode {
     // ========================
     DUPLICATE_EMAIL(409_001, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     ALREADY_WITHDRAWN_USER(409_004, HttpStatus.CONFLICT, "이미 탈퇴한 회원입니다."),
+    STORY_THUMBNAIL_NOT_ALLOWED(409_005, HttpStatus.CONFLICT, "썸네일을 생성할 수 없는 상태입니다."),
 
 
     // ========================
@@ -76,6 +78,9 @@ public enum ErrorCode {
     KAKAO_TOKEN_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "카카오 토큰을 가져오는 중 오류가 발생했습니다."),
     KAKAO_USER_INFO_ERROR(500_002, HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보를 가져오는 중 오류가 발생했습니다."),
     REDIS_CONNECTION_FAILED(500_003, HttpStatus.INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),
+    PYTHON_PROCESS_FAILED(500_004, HttpStatus.INTERNAL_SERVER_ERROR, "파이썬 프로세스 처리 중 오류가 발생했습니다."),
+    SUPABASE_UPLOAD_FAILED(502_001, HttpStatus.BAD_GATEWAY, "파일 업로드 중 오류가 발생했습니다."),
+    PYTHON_PROCESS_TIMEOUT(504_001, HttpStatus.GATEWAY_TIMEOUT, "파이썬 프로세스가 제한 시간 내 종료되지 않았습니다."),
 
     ;
 

--- a/src/main/java/pproject/once_upon_a_time/infrastructure/PythonImageGenRunner.java
+++ b/src/main/java/pproject/once_upon_a_time/infrastructure/PythonImageGenRunner.java
@@ -1,0 +1,111 @@
+package pproject.once_upon_a_time.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import pproject.once_upon_a_time.global.exception.CustomException;
+import pproject.once_upon_a_time.global.exception.ErrorCode;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PythonImageGenRunner {
+
+    @Value("${python.image-path}")
+    private String scriptPath;
+
+    @Value("${python.timeout-seconds:120}")
+    private long timeoutSeconds;
+
+    /**
+     * 파이썬 스크립트에 JSON 문자열을 stdin으로 전달하고 stdout 전체를 반환한다.
+     */
+    public String run(String inputJson) {
+        validateScriptPath();
+
+        ProcessBuilder processBuilder = new ProcessBuilder("python3", scriptPath);
+        processBuilder.redirectErrorStream(false);
+
+        Process process;
+        try {
+            process = processBuilder.start();
+            writeToProcess(process, inputJson);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 프로세스 시작 실패: " + e.getMessage());
+        }
+
+        String stdout = readStream(process.getInputStream());
+        String stderr = readStream(process.getErrorStream());
+
+        boolean exited;
+        try {
+            exited = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 프로세스가 인터럽트되었습니다.");
+        }
+
+        if (!exited) {
+            process.destroyForcibly();
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_TIMEOUT,
+                    "파이썬 프로세스 타임아웃(" + timeoutSeconds + "초)으로 종료되었습니다.");
+        }
+
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            log.error("Python stderr: {}", stderr);
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED,
+                    "파이썬 프로세스가 실패했습니다. exitCode=" + exitCode + ", stderr=" + stderr);
+        }
+
+        if (!stderr.isBlank()) {
+            log.warn("Python stderr: {}", stderr);
+        }
+
+        log.debug("Python stdout: {}", stdout);
+        return stdout;
+    }
+
+    private void writeToProcess(Process process, String inputJson) throws IOException {
+        try (OutputStreamWriter writer = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8)) {
+            writer.write(inputJson);
+            writer.flush();
+        }
+    }
+
+    private String readStream(InputStream inputStream) {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!sb.isEmpty()) {
+                    sb.append(System.lineSeparator());
+                }
+                sb.append(line);
+            }
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 프로세스 출력 읽기 실패: " + e.getMessage());
+        }
+        return sb.toString();
+    }
+
+    private void validateScriptPath() {
+        if (scriptPath == null || scriptPath.isBlank()) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "python.script-path 설정이 비어 있습니다.");
+        }
+    }
+
+    public Duration getTimeout() {
+        return Duration.ofSeconds(timeoutSeconds);
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/infrastructure/SupabaseStorageService.java
+++ b/src/main/java/pproject/once_upon_a_time/infrastructure/SupabaseStorageService.java
@@ -55,6 +55,19 @@ public class SupabaseStorageService {
         return uploadToBucket(file, bucket);
     }
 
+    /**
+     * PNG 바이트 배열을 지정한 파일명으로 이미지 버킷에 업로드한다.
+     */
+    public String uploadImageBytes(byte[] imageBytes, String fileName) {
+        if (imageBytes == null || imageBytes.length == 0) {
+            throw new IllegalArgumentException("이미지 데이터가 비어 있습니다.");
+        }
+        String objectName = (fileName == null || fileName.isBlank())
+                ? UUID.randomUUID() + ".png"
+                : fileName;
+        return uploadToBucket(imageBytes, imageBucket, MediaType.IMAGE_PNG, objectName);
+    }
+
     private void validateMimeType(MultipartFile file, FileType type) {
         String contentType = file.getContentType();
         if (contentType == null) {
@@ -73,20 +86,22 @@ public class SupabaseStorageService {
 
     private String uploadToBucket(MultipartFile file, String bucket) throws IOException {
         String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+        MediaType mediaType = file.getContentType() != null
+                ? MediaType.parseMediaType(file.getContentType())
+                : MediaType.APPLICATION_OCTET_STREAM;
+        return uploadToBucket(file.getBytes(), bucket, mediaType, fileName);
+    }
 
+    private String uploadToBucket(byte[] data, String bucket, MediaType mediaType, String fileName) {
         // Supabase 업로드 endpoint
         String uploadUrl = supabaseUrl + "/storage/v1/object/" + bucket + "/" + fileName;
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("apikey", serviceKey);
         headers.set("Authorization", "Bearer " + serviceKey);
-
-        MediaType mediaType = file.getContentType() != null
-                ? MediaType.parseMediaType(file.getContentType())
-                : MediaType.APPLICATION_OCTET_STREAM;
         headers.setContentType(mediaType);
 
-        HttpEntity<byte[]> request = new HttpEntity<>(file.getBytes(), headers);
+        HttpEntity<byte[]> request = new HttpEntity<>(data, headers);
 
         ResponseEntity<String> response = restTemplate.exchange(
                 uploadUrl,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,3 +29,7 @@ logging:
 ai:
   python-path: ${AI_PYTHON_PATH}
   script-path: ${AI_SCRIPT_PATH}
+
+python:
+  image-path: content/image_mock.py
+  timeout-seconds: 120

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,3 +24,7 @@ server:
 ai:
   python-path: ${AI_PYTHON_PATH}
   script-path: ${AI_SCRIPT_PATH}
+
+python:
+  image-path: /home/t25301/ai/image_generator.py
+  timeout-seconds: 120

--- a/src/test/java/pproject/once_upon_a_time/domain/story/service/StoryThumbnailServiceTest.java
+++ b/src/test/java/pproject/once_upon_a_time/domain/story/service/StoryThumbnailServiceTest.java
@@ -1,0 +1,128 @@
+package pproject.once_upon_a_time.domain.story.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pproject.once_upon_a_time.domain.member.domain.Member;
+import pproject.once_upon_a_time.domain.story.domain.GenerationStatus;
+import pproject.once_upon_a_time.domain.story.domain.Story;
+import pproject.once_upon_a_time.domain.story.repository.StoryRepository;
+import pproject.once_upon_a_time.global.common.MemberRole;
+import pproject.once_upon_a_time.global.exception.CustomException;
+import pproject.once_upon_a_time.infrastructure.PythonImageGenRunner;
+import pproject.once_upon_a_time.infrastructure.SupabaseStorageService;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StoryThumbnailServiceTest {
+
+    @Mock
+    private StoryRepository storyRepository;
+
+    @Mock
+    private PythonImageGenRunner pythonImageGenRunner;
+
+    @Mock
+    private SupabaseStorageService supabaseStorageService;
+
+    private StoryThumbnailService storyThumbnailService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String BASE64_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6X4Z9kAAAAASUVORK5CYII=";
+
+    @BeforeEach
+    void setUp() {
+        storyThumbnailService = new StoryThumbnailService(
+                storyRepository,
+                pythonImageGenRunner,
+                supabaseStorageService,
+                objectMapper
+        );
+    }
+
+    @Test
+    void generateThumbnail_returnsUploadedUrl() {
+        Member owner = createMember(1L);
+        Story story = createStory(owner, GenerationStatus.COMPLETED, null);
+
+        given(storyRepository.findById(1L)).willReturn(Optional.of(story));
+        given(pythonImageGenRunner.run(any())).willReturn(
+                "{\"success\": true, \"data\": {\"image_base64\": \"" + BASE64_IMAGE + "\"}}"
+        );
+        given(supabaseStorageService.uploadImageBytes(any(), eq("stories/1/thumbnail.png")))
+                .willReturn("https://example.com/thumbnail.png");
+
+        String result = storyThumbnailService.generateThumbnail(1L, owner);
+
+        assertThat(result).isEqualTo("https://example.com/thumbnail.png");
+        assertThat(story.getThumbnailUrl()).isEqualTo("https://example.com/thumbnail.png");
+    }
+
+    @Test
+    void generateThumbnail_returnsExistingUrlWhenAlreadyPresent() {
+        Member owner = createMember(1L);
+        Story story = createStory(owner, GenerationStatus.COMPLETED, "https://existing.png");
+        given(storyRepository.findById(1L)).willReturn(Optional.of(story));
+
+        String result = storyThumbnailService.generateThumbnail(1L, owner);
+
+        assertThat(result).isEqualTo("https://existing.png");
+    }
+
+    @Test
+    void generateThumbnail_throwsWhenOwnerMismatch() {
+        Member owner = createMember(1L);
+        Member other = createMember(2L);
+        Story story = createStory(owner, GenerationStatus.COMPLETED, null);
+        given(storyRepository.findById(1L)).willReturn(Optional.of(story));
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> storyThumbnailService.generateThumbnail(1L, other));
+
+        assertThat(exception.getErrorCode()).isNotNull();
+    }
+
+    @Test
+    void generateThumbnail_throwsWhenStatusNotCompleted() {
+        Member owner = createMember(1L);
+        Story story = createStory(owner, GenerationStatus.PROCESSING, null);
+        given(storyRepository.findById(1L)).willReturn(Optional.of(story));
+
+        assertThrows(CustomException.class, () -> storyThumbnailService.generateThumbnail(1L, owner));
+    }
+
+    private Member createMember(Long id) {
+        return Member.builder()
+                .id(id)
+                .kakaoUserId("kakao-" + id)
+                .name("name" + id)
+                .nickname("nick" + id)
+                .role(MemberRole.USER)
+                .build();
+    }
+
+    private Story createStory(Member member, GenerationStatus status, String thumbnailUrl) {
+        return Story.builder()
+                .id(1L)
+                .member(member)
+                .title("title")
+                .content("content")
+                .keywords(List.of("a", "b"))
+                .generationStatus(status)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+}


### PR DESCRIPTION


## 🚀 Related Issue
- #63

## 📄 Description

 - 썸네일 생성 파이프라인 추가: Story 소유자/상태 검증 후 파이썬 child process 호출→stdout JSON 파싱→base64 디코드→Supabase 업로드→Story에 URL 저장. 기존 URL 있으면 재
    사용.
  - 인프라: PythonImageGenRunner로 파이썬 실행/타임아웃/에러 처리, Supabase에 바이트 배열 업로드용 uploadImageBytes 추가. 파이썬 설정 키를 python.image-path로 명확화.
  - API: POST /api/v1/stories/{storyId}/thumbnail 엔드포인트 추가(StoryController), 응답 DTO StoryThumbnailResponseDto.
  - 설정/스텁: dev용 content/image_mock.py(고정 1x1 PNG 반환), prod는 기존 content/image_generator.py 경로로 설정. application-*.yml에 python.image-path/timeout-seconds
    추가.
  - 에러 코드: 소유자 불일치(403), 상태 불가(409), 파이썬 실패/타임아웃(500/504), 업로드 실패(502) 등 확장.

## ✅ Test Checklist
- [ ] 테스트 코드를 작성하셨나요?
- [ ] 직접 Postman이나 DB를 통해 확인해 보셨나요?

## 📸 Screenshots
<img width="1416" height="1057" alt="image" src="https://github.com/user-attachments/assets/f0b52417-2308-406c-bc4a-1a2e3742e1e3" />