### PR TITLE
[Feat] 관리자 페이지 기능 구현

### DIFF
--- a/src/main/java/pproject/once_upon_a_time/domain/admin/controller/AdminController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/admin/controller/AdminController.java
@@ -1,0 +1,48 @@
+package pproject.once_upon_a_time.domain.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pproject.once_upon_a_time.domain.admin.dto.AdminAudioBookResponseDto;
+import pproject.once_upon_a_time.domain.admin.dto.AdminMemberResponseDto;
+import pproject.once_upon_a_time.domain.admin.dto.AdminStoryResponseDto;
+import pproject.once_upon_a_time.domain.admin.service.AdminService;
+import pproject.once_upon_a_time.global.response.ApiResult;
+
+import java.util.List;
+
+@Tag(name = "Admin API", description = "관리자 전용 기능 (ADMIN 권한 필수)")
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(summary = "전체 회원 조회")
+    @GetMapping("/members")
+    public ResponseEntity<ApiResult<List<AdminMemberResponseDto>>> getAllMembers() {
+        return ResponseEntity.ok(ApiResult.ok(adminService.getAllMembers()));
+    }
+
+    @Operation(summary = "회원 강제 탈퇴")
+    @DeleteMapping("/members/{memberId}")
+    public ResponseEntity<ApiResult<Void>> deleteMember(@PathVariable Long memberId) {
+        adminService.deleteMember(memberId);
+        return ResponseEntity.ok(ApiResult.ok(null));
+    }
+
+    @Operation(summary = "전체 동화 조회")
+    @GetMapping("/stories")
+    public ResponseEntity<ApiResult<List<AdminStoryResponseDto>>> getAllStories() {
+        return ResponseEntity.ok(ApiResult.ok(adminService.getAllStories()));
+    }
+
+    @Operation(summary = "전체 오디오북 조회")
+    @GetMapping("/audiobooks")
+    public ResponseEntity<ApiResult<List<AdminAudioBookResponseDto>>> getAllAudioBooks() {
+        return ResponseEntity.ok(ApiResult.ok(adminService.getAllAudioBooks()));
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/admin/dto/AdminAudioBookResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/admin/dto/AdminAudioBookResponseDto.java
@@ -1,0 +1,23 @@
+package pproject.once_upon_a_time.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import pproject.once_upon_a_time.domain.audiobook.domain.AudioBook;
+
+@Getter
+@Builder
+public class AdminAudioBookResponseDto {
+    private Long audioBookId;
+    private String storyTitle;
+    private String memberName;    // 만든 사람 추가
+    private String characterName; // 캐릭터 이름 추가
+
+    public static AdminAudioBookResponseDto from(AudioBook audioBook) {
+        return AdminAudioBookResponseDto.builder()
+            .audioBookId(audioBook.getId())
+            .storyTitle(audioBook.getStory().getTitle())
+            .memberName(audioBook.getMember().getName())
+            .characterName(audioBook.getCharacter().getCharacterName())
+            .build();
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/admin/dto/AdminMemberResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/admin/dto/AdminMemberResponseDto.java
@@ -1,0 +1,29 @@
+package pproject.once_upon_a_time.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import pproject.once_upon_a_time.domain.member.domain.Member;
+import pproject.once_upon_a_time.global.common.MemberRole;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminMemberResponseDto {
+    private Long memberId;
+    private String name;
+    private String nickname;
+    private String kakaoUserId;
+    private MemberRole role;
+    private LocalDateTime joinDate; // 가입일 추가
+
+    public static AdminMemberResponseDto from(Member member) {
+        return AdminMemberResponseDto.builder()
+            .memberId(member.getId())
+            .name(member.getName())
+            .nickname(member.getNickname())
+            .kakaoUserId(member.getKakaoUserId())
+            .role(member.getRole())
+            .joinDate(member.getCreatedDate())
+            .build();
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/admin/dto/AdminStoryResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/admin/dto/AdminStoryResponseDto.java
@@ -1,0 +1,26 @@
+package pproject.once_upon_a_time.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import pproject.once_upon_a_time.domain.story.domain.Story;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminStoryResponseDto {
+    private Long storyId;
+    private String title;
+    private String writerName;
+    private String theme;
+    private LocalDateTime createdDate;
+
+    public static AdminStoryResponseDto from(Story story) {
+        return AdminStoryResponseDto.builder()
+            .storyId(story.getId())
+            .title(story.getTitle())
+            .writerName(story.getMember().getName())
+            .theme(story.getTheme())
+            .createdDate(story.getCreatedDate())
+            .build();
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/admin/service/AdminService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/admin/service/AdminService.java
@@ -1,0 +1,53 @@
+package pproject.once_upon_a_time.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pproject.once_upon_a_time.domain.admin.dto.AdminAudioBookResponseDto;
+import pproject.once_upon_a_time.domain.admin.dto.AdminMemberResponseDto;
+import pproject.once_upon_a_time.domain.admin.dto.AdminStoryResponseDto;
+import pproject.once_upon_a_time.domain.audiobook.repository.AudioBookRepository;
+import pproject.once_upon_a_time.domain.member.repository.MemberRepository;
+import pproject.once_upon_a_time.domain.story.repository.StoryRepository;
+import pproject.once_upon_a_time.global.exception.CustomException;
+import pproject.once_upon_a_time.global.exception.ErrorCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+
+    private final MemberRepository memberRepository;
+    private final StoryRepository storyRepository;
+    private final AudioBookRepository audioBookRepository;
+
+    public List<AdminMemberResponseDto> getAllMembers() {
+        return memberRepository.findAll().stream()
+            .map(AdminMemberResponseDto::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteMember(Long memberId) {
+        // 안전한 삭제를 위해 존재 확인
+        if (!memberRepository.existsById(memberId)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND); // 에러코드 없으면 IllegalArgumentException 사용
+        }
+        memberRepository.deleteById(memberId);
+    }
+
+    public List<AdminStoryResponseDto> getAllStories() {
+        return storyRepository.findAll().stream()
+            .map(AdminStoryResponseDto::from)
+            .collect(Collectors.toList());
+    }
+
+    public List<AdminAudioBookResponseDto> getAllAudioBooks() {
+        return audioBookRepository.findAll().stream()
+            .map(AdminAudioBookResponseDto::from)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/member/domain/Member.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/member/domain/Member.java
@@ -3,6 +3,7 @@ package pproject.once_upon_a_time.domain.member.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import pproject.once_upon_a_time.domain.audiobook.domain.AudioBook;
+import pproject.once_upon_a_time.global.common.BaseTimeEntity;
 import pproject.once_upon_a_time.global.common.MemberRole;
 
 import java.time.LocalDate;
@@ -14,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "member")
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/pproject/once_upon_a_time/domain/story/dto/StoryListResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/dto/StoryListResponseDto.java
@@ -8,29 +8,15 @@ import java.time.LocalDateTime;
 @Getter
 
 public class StoryListResponseDto {
-
-
-
     private final Long id;
-
     private final String title;
-
     private final String thumbnailUrl;
-
     private final LocalDateTime createdDate;
 
-
-
     public StoryListResponseDto(Story story) {
-
         this.id = story.getId();
-
         this.title = story.getTitle();
-
         this.thumbnailUrl = story.getThumbnailUrl();
-
         this.createdDate = story.getCreatedDate();
-
     }
-
 }

--- a/src/main/java/pproject/once_upon_a_time/global/auth/config/SecurityConfig.java
+++ b/src/main/java/pproject/once_upon_a_time/global/auth/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                     "/swagger-ui.html",
                     "/api/v1/auth/**" // 여기에 reissue 포함됨
                 ).permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/pproject/once_upon_a_time/global/auth/config/SecurityConfig.java
+++ b/src/main/java/pproject/once_upon_a_time/global/auth/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                     "/swagger-ui.html",
                     "/api/v1/auth/**" // 여기에 reissue 포함됨
                 ).permitAll()
-                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION

## 🚀 Related Issue
- closed #73 

## 📄 Description
- 멤버 전체 조회, 동화 전체 조회, 오디오북 전체 조회, 멤버 삭제 기능을 구현했습니다.

## ✅ Test Checklist
- [ ] 테스트 코드를 작성하셨나요?
- [x] 직접 Postman이나 DB를 통해 확인해 보셨나요?

## 📸 Screenshots
- 멤버 조회
<img width="840" height="683" alt="스크린샷 2025-12-16 오전 2 04 03" src="https://github.com/user-attachments/assets/67bb451f-b455-4db5-a152-8e5038c0134e" />

- 동화 조회
<img width="849" height="682" alt="스크린샷 2025-12-16 오전 2 04 34" src="https://github.com/user-attachments/assets/342d8155-77cf-4b19-83f0-8757fb12b0b7" />

- 오디오북 조회
<img width="849" height="649" alt="스크린샷 2025-12-16 오전 2 04 53" src="https://github.com/user-attachments/assets/279ab79c-dfe7-4194-9f80-1fafe91cfb5b" />

- 멤버 DB
<img width="723" height="259" alt="스크린샷 2025-12-16 오전 2 06 16" src="https://github.com/user-attachments/assets/0dae7af1-9ed2-43b4-bff7-62a5d082ac07" />

- 멤버 삭제
<img width="852" height="415" alt="스크린샷 2025-12-16 오전 2 06 45" src="https://github.com/user-attachments/assets/750c979f-f919-499d-afcd-9e19b48b5e12" />
<img width="727" height="259" alt="스크린샷 2025-12-16 오전 2 06 56" src="https://github.com/user-attachments/assets/4c2ba422-0314-4684-a7c1-1817a2c6a674" />





