### PR TITLE
[Feat] 오디오북 생성 api 구현

### DIFF
--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/controller/AudioBookController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/controller/AudioBookController.java
@@ -1,20 +1,26 @@
 package pproject.once_upon_a_time.domain.audiobook.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pproject.once_upon_a_time.auth.annotation.LoginUser;
+import pproject.once_upon_a_time.domain.audiobook.domain.AudioBook;
+import pproject.once_upon_a_time.domain.audiobook.dto.AudioBookMakeRequest;
+import pproject.once_upon_a_time.domain.audiobook.dto.AudioBookMakeResponse;
 import pproject.once_upon_a_time.domain.audiobook.dto.AudioBookResponseDto;
 import pproject.once_upon_a_time.domain.audiobook.service.AudioBookService;
 import pproject.once_upon_a_time.domain.member.domain.Member;
@@ -22,14 +28,14 @@ import pproject.once_upon_a_time.global.response.ApiResult;
 import pproject.once_upon_a_time.global.response.ExceptionDto;
 
 @RestController
-@RequestMapping("/api/v1/audiobooks")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "Audiobooks", description = "오디오북 조회 API")
 public class AudioBookController {
 
     private final AudioBookService audioBookService;
 
-    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/audiobooks", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(
             summary = "오디오북 리스트 조회",
             description = "로그인한 사용자의 오디오북 리스트를 반환합니다.",
@@ -45,6 +51,39 @@ public class AudioBookController {
             @Parameter(hidden = true) @LoginUser Member member) {
         AudioBookResponseDto response = audioBookService.getAudioBooks(member);
         var body = ApiResult.ok(response);
+        return ResponseEntity.status(body.httpStatus()).body(body);
+    }
+
+    @PostMapping(
+            value = "/audiobook/make",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(
+            summary = "오디오북 생성",
+            description = "스토리와 캐릭터를 선택해 오디오북을 생성합니다.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력"),
+            @ApiResponse(responseCode = "404", description = "스토리 또는 캐릭터 없음")
+    })
+    public ResponseEntity<ApiResult<AudioBookMakeResponse>> makeAudioBook(
+            @Valid @RequestBody AudioBookMakeRequest request,
+            @Parameter(hidden = true) @LoginUser Member member
+    ) {
+        AudioBook audioBook = audioBookService.makeAudioBook(request.getStoryId(), request.getCharacterId(), member);
+
+        AudioBookMakeResponse response = AudioBookMakeResponse.builder()
+                .audioBookId(audioBook.getId())
+                .audioUrl(audioBook.getAudioUrl())
+                .duration(audioBook.getDuration())
+                .storyId(request.getStoryId())
+                .characterId(request.getCharacterId())
+                .build();
+
+        var body = ApiResult.created(response);
         return ResponseEntity.status(body.httpStatus()).body(body);
     }
 

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/controller/AudioBookController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/controller/AudioBookController.java
@@ -103,7 +103,7 @@ public class AudioBookController {
                         "분위기",
                         "https://example.com/thumbnail.jpg",
                         "캐릭터 이름",
-                        600
+                        60.4
                 ))
         );
 

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/domain/AudioBook.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/domain/AudioBook.java
@@ -35,6 +35,6 @@ public class AudioBook {
     private String audioUrl;
 
     @Column(name = "duration", nullable = false)
-    private Integer duration;
+    private Double duration;
     
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookMakeRequest.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookMakeRequest.java
@@ -1,0 +1,25 @@
+package pproject.once_upon_a_time.domain.audiobook.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "오디오북 생성 요청 DTO")
+public class AudioBookMakeRequest {
+
+    @NotNull
+    @Schema(description = "스토리 ID", example = "1")
+    private Long storyId;
+
+    @NotNull
+    @Schema(description = "캐릭터 ID", example = "2")
+    private Long characterId;
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookMakeResponse.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookMakeResponse.java
@@ -20,8 +20,8 @@ public class AudioBookMakeResponse {
     @Schema(description = "오디오북 URL", example = "https://mock.storage.local/audiobooks/title_voice.wav")
     private String audioUrl;
 
-    @Schema(description = "총 재생 시간(초)", example = "12")
-    private Integer duration;
+    @Schema(description = "총 재생 시간(초, 소수점 허용)", example = "12.34")
+    private Double duration;
 
     @Schema(description = "스토리 ID", example = "1")
     private Long storyId;

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookMakeResponse.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookMakeResponse.java
@@ -1,0 +1,31 @@
+package pproject.once_upon_a_time.domain.audiobook.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "오디오북 생성 응답 DTO")
+public class AudioBookMakeResponse {
+
+    @Schema(description = "오디오북 ID", example = "10")
+    private Long audioBookId;
+
+    @Schema(description = "오디오북 URL", example = "https://mock.storage.local/audiobooks/title_voice.wav")
+    private String audioUrl;
+
+    @Schema(description = "총 재생 시간(초)", example = "12")
+    private Integer duration;
+
+    @Schema(description = "스토리 ID", example = "1")
+    private Long storyId;
+
+    @Schema(description = "캐릭터 ID", example = "2")
+    private Long characterId;
+}

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookResponseDto.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/AudioBookResponseDto.java
@@ -45,7 +45,7 @@ public class AudioBookResponseDto {
         @Schema(description = "캐릭터 이름", example = "루비")
         private String characterName;
 
-        @Schema(description = "오디오북 길이(초)", example = "600")
-        private Integer duration;
+        @Schema(description = "오디오북 길이(초, 소수점 허용)", example = "600.5")
+        private Double duration;
     }
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/PlaybackInfoResponse.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/dto/PlaybackInfoResponse.java
@@ -29,8 +29,8 @@ public class PlaybackInfoResponse {
     @Schema(description = "재생 상태", example = "PLAYING")
     private PlaybackStatus status;
 
-    @Schema(description = "오디오북 길이(초)", example = "600")
-    private Integer duration;
+    @Schema(description = "오디오북 길이(초, 소수점 허용)", example = "600.25")
+    private Double duration;
 
     @Schema(description = "동화 제목", example = "숲속의 용감한 토끼")
     private String storyTitle;

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookService.java
@@ -75,7 +75,7 @@ public class AudioBookService {
                 .character(character)
                 .member(authenticatedMember)
                 .audioUrl(result.audioUrl())
-                .duration(result.durationSecondsRounded())
+                .duration(result.durationSeconds())
                 .build();
 
         return audioBookRepository.save(audioBook);

--- a/src/main/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookService.java
@@ -3,23 +3,85 @@ package pproject.once_upon_a_time.domain.audiobook.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import pproject.once_upon_a_time.domain.audiobook.domain.AudioBook;
 import pproject.once_upon_a_time.domain.audiobook.dto.AudioBookResponseDto;
+import pproject.once_upon_a_time.domain.character.domain.Character;
+import pproject.once_upon_a_time.domain.character.repository.CharacterRepository;
 import pproject.once_upon_a_time.domain.audiobook.repository.AudioBookRepository;
 import pproject.once_upon_a_time.domain.member.domain.Member;
+import pproject.once_upon_a_time.domain.script.domain.Script;
+import pproject.once_upon_a_time.domain.script.repository.ScriptRepository;
+import pproject.once_upon_a_time.domain.story.domain.Story;
+import pproject.once_upon_a_time.domain.story.repository.StoryRepository;
 import pproject.once_upon_a_time.global.exception.CustomException;
 import pproject.once_upon_a_time.global.exception.ErrorCode;
+import pproject.once_upon_a_time.infrastructure.PythonAudioBookRunner;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class AudioBookService {
 
     private final AudioBookRepository audioBookRepository;
+    private final StoryRepository storyRepository;
+    private final CharacterRepository characterRepository;
+    private final ScriptRepository scriptRepository;
+    private final PythonAudioBookRunner pythonAudioBookRunner;
 
     // 회원이 보유한 오디오북 목록을 조회한다.
     @Transactional(readOnly = true)
     public AudioBookResponseDto getAudioBooks(Member member) {
+        Member authenticatedMember = requireAuthenticatedMember(member);
+
+        List<AudioBookResponseDto.Item> items = audioBookRepository.findItemsByMemberId(authenticatedMember.getId());
+        return new AudioBookResponseDto(items);
+    }
+
+    @Transactional
+    public AudioBook makeAudioBook(Long storyId, Long characterId, Member member) {
+        Member authenticatedMember = requireAuthenticatedMember(member);
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORY_NOT_FOUND));
+        Character character = characterRepository.findById(characterId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHARACTER_NOT_FOUND));
+
+        List<Script> scripts = scriptRepository.findByStoryIdOrderBySeqAsc(storyId);
+        if (scripts.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT, "해당 스토리에 스크립트가 없습니다.");
+        }
+
+        List<PythonAudioBookRunner.ScriptItem> scriptItems = scripts.stream()
+                .map(script -> new PythonAudioBookRunner.ScriptItem(
+                        script.getSeq(),
+                        Objects.toString(script.getText(), "")
+                ))
+                .toList();
+
+        String title = Objects.toString(story.getTitle(), "Untitled");
+        String narratorVoice = Objects.toString(character.getCharacterName(), "UNKNOWN");
+
+        PythonAudioBookRunner.AudioBookPayload payload = new PythonAudioBookRunner.AudioBookPayload(
+                title,
+                narratorVoice,
+                scriptItems
+        );
+
+        PythonAudioBookRunner.AudioBookResult result = pythonAudioBookRunner.run(payload);
+
+        AudioBook audioBook = AudioBook.builder()
+                .story(story)
+                .character(character)
+                .member(authenticatedMember)
+                .audioUrl(result.audioUrl())
+                .duration(result.durationSecondsRounded())
+                .build();
+
+        return audioBookRepository.save(audioBook);
+    }
+
+    private Member requireAuthenticatedMember(Member member) {
         if (member == null) {
             throw new CustomException(ErrorCode.INVALID_LOGIN);
         }
@@ -29,7 +91,6 @@ public class AudioBookService {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
-        List<AudioBookResponseDto.Item> items = audioBookRepository.findItemsByMemberId(memberId);
-        return new AudioBookResponseDto(items);
+        return member;
     }
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/playback/scheduler/PlaybackFlushScheduler.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/playback/scheduler/PlaybackFlushScheduler.java
@@ -79,7 +79,7 @@ public class PlaybackFlushScheduler {
             return;
         }
 
-        int duration = Optional.ofNullable(audioBookOpt.get().getDuration()).orElse(0);
+        double duration = Optional.ofNullable(audioBookOpt.get().getDuration()).orElse(0.0d);
         float progressRate = calculateProgressRate(duration, lastPosition);
         int listenedDuration = lastPosition;
         PlaybackStatus status = Optional.ofNullable(parsed.value.getStatus()).orElse(PlaybackStatus.PLAYING);
@@ -87,12 +87,12 @@ public class PlaybackFlushScheduler {
         playbackRepository.updateProgress(audiobookId, memberId, lastPosition, progressRate, listenedDuration, status);
     }
 
-    private float calculateProgressRate(Integer duration, Integer position) {
+    private float calculateProgressRate(Double duration, Integer position) {
         if (duration == null || duration <= 0) {
             return 0f;
         }
         int safePosition = Optional.ofNullable(position).orElse(0);
-        float rate = (float) safePosition / duration;
+        float rate = (float) (safePosition / duration);
         return Math.min(1.0f, Math.max(0f, rate));
     }
 

--- a/src/main/java/pproject/once_upon_a_time/domain/playback/service/PlaybackService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/playback/service/PlaybackService.java
@@ -202,17 +202,17 @@ public class PlaybackService {
     }
 
     // 진행률 계산 (duration 기반)
-    private float calculateProgressRate(Integer duration, Integer position) {
+    private float calculateProgressRate(Double duration, Integer position) {
         if (duration == null || duration <= 0) {
             return 0f;
         }
         int safePosition = Optional.ofNullable(position).orElse(0);
-        float rate = (float) safePosition / duration;
+        float rate = (float) (safePosition / duration);
         return Math.min(1.0f, Math.max(0f, rate));
     }
 
     // int 입력용 진행률 계산
-    private float calculateProgressRate(Integer duration, int position) {
+    private float calculateProgressRate(Double duration, int position) {
         return calculateProgressRate(duration, Integer.valueOf(position));
     }
 

--- a/src/main/java/pproject/once_upon_a_time/domain/script/repository/ScriptRepository.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/script/repository/ScriptRepository.java
@@ -3,5 +3,8 @@ package pproject.once_upon_a_time.domain.script.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import pproject.once_upon_a_time.domain.script.domain.Script;
 
+import java.util.List;
+
 public interface ScriptRepository extends JpaRepository<Script, Long> {
+    List<Script> findByStoryIdOrderBySeqAsc(Long storyId);
 }

--- a/src/main/java/pproject/once_upon_a_time/infrastructure/PythonAudioBookRunner.java
+++ b/src/main/java/pproject/once_upon_a_time/infrastructure/PythonAudioBookRunner.java
@@ -1,0 +1,174 @@
+package pproject.once_upon_a_time.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import pproject.once_upon_a_time.global.exception.CustomException;
+import pproject.once_upon_a_time.global.exception.ErrorCode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PythonAudioBookRunner {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${ai.python-path:python3}")
+    private String pythonBin;
+
+    @Value("${python.audiobook-path}")
+    private String scriptPath;
+
+    @Value("${python.timeout-seconds:300}")
+    private long timeoutSeconds;
+
+    public AudioBookResult run(AudioBookPayload payload) {
+        validateConfig();
+        String inputJson = toJson(payload);
+
+        Process process;
+        try {
+            process = new ProcessBuilder(pythonBin, resolveScriptPath()).start();
+            writeInput(process, inputJson);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 프로세스 시작 실패: " + e.getMessage());
+        }
+
+        boolean finished = waitFor(process);
+        String stdout = readAll(process.getInputStream());
+        String stderr = readAll(process.getErrorStream());
+
+        if (!finished) {
+            process.destroyForcibly();
+            throw new CustomException(
+                    ErrorCode.PYTHON_PROCESS_TIMEOUT,
+                    "파이썬 프로세스가 제한 시간(" + timeoutSeconds + "초) 내 종료되지 않았습니다. stderr=" + stderr
+            );
+        }
+
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            log.error("Python stdout: {}", stdout);
+            log.error("Python stderr: {}", stderr);
+            throw new CustomException(
+                    ErrorCode.PYTHON_PROCESS_FAILED,
+                    "파이썬 프로세스 실패(exitCode=" + exitCode + "). stdout=" + stdout + " stderr=" + stderr
+            );
+        }
+
+        if (!stderr.isBlank()) {
+            log.warn("Python stderr: {}", stderr);
+        }
+
+        return parse(stdout);
+    }
+
+    private String resolveScriptPath() {
+        return Path.of(scriptPath).toAbsolutePath().toString();
+    }
+
+    private void validateConfig() {
+        if (scriptPath == null || scriptPath.isBlank()) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "python.audiobook-path 설정이 비어 있습니다.");
+        }
+        if (pythonBin == null || pythonBin.isBlank()) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "ai.python-path 설정이 비어 있습니다.");
+        }
+    }
+
+    private String toJson(AudioBookPayload payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 입력 JSON 직렬화 실패: " + e.getMessage());
+        }
+    }
+
+    private void writeInput(Process process, String inputJson) throws IOException {
+        try (OutputStreamWriter writer = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8)) {
+            writer.write(inputJson);
+            writer.flush();
+        }
+    }
+
+    private boolean waitFor(Process process) {
+        try {
+            return process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 프로세스가 인터럽트되었습니다.");
+        }
+    }
+
+    private String readAll(InputStream inputStream) {
+        try {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력 읽기 실패: " + e.getMessage());
+        }
+    }
+
+    private AudioBookResult parse(String stdout) {
+        if (stdout == null || stdout.isBlank()) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력이 비어 있습니다.");
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(stdout);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력 파싱 실패: " + e.getMessage());
+        }
+
+        boolean success = root.path("success").asBoolean(false);
+        if (!success) {
+            String errorMessage = root.path("error").asText("알 수 없는 오류");
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 프로세스 실패 응답: " + errorMessage);
+        }
+
+        JsonNode audioNode = root.path("data").path("audiobook");
+        String audioUrl = audioNode.path("url").asText(null);
+        double durationSeconds = audioNode.path("duration").asDouble(Double.NaN);
+
+        if (audioUrl == null || audioUrl.isBlank()) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 결과에 오디오 URL이 없습니다.");
+        }
+        if (Double.isNaN(durationSeconds)) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 결과에 재생 시간이 없습니다.");
+        }
+
+        return new AudioBookResult(audioUrl, durationSeconds);
+    }
+
+    public record AudioBookPayload(
+            @JsonProperty("title") String title,
+            @JsonProperty("narrator_voice") String narratorVoice,
+            @JsonProperty("script") List<ScriptItem> scriptItems
+    ) {
+    }
+
+    public record ScriptItem(
+            @JsonProperty("seq") Integer seq,
+            @JsonProperty("text") String text
+    ) {
+    }
+
+    public record AudioBookResult(String audioUrl, double durationSeconds) {
+        public int durationSecondsRounded() {
+            return (int) Math.round(durationSeconds);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,4 +32,5 @@ ai:
 
 python:
   image-path: content/image_mock.py
+  audiobook-path: content/audio_mock.py
   timeout-seconds: 120

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,4 +27,5 @@ ai:
 
 python:
   image-path: /home/t25301/ai/image_generator.py
+  audiobook-path: /home/t25301/ai/audiobook_generator.py
   timeout-seconds: 120

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>Backend Server</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f7f7f7;
+            display: flex;
+            height: 100vh;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            background: #ffffff;
+            padding: 32px 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+        h1 {
+            margin-bottom: 24px;
+            font-size: 20px;
+        }
+        a.button {
+            display: block;
+            margin: 12px 0;
+            padding: 12px;
+            background: #2f80ed;
+            color: #ffffff;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: bold;
+        }
+        a.button.secondary {
+            background: #4f4f4f;
+        }
+        a.button:hover {
+            opacity: 0.9;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>옛날옛적의 백엔드 서버입니다.</h1>
+
+    <!-- Swagger -->
+    <a class="button" href="/swagger-ui/index.html">
+        Swagger API Docs
+    </a>
+
+    <!-- 현재 배포 서버(API 루트 확인용) -->
+    <a class="button secondary" href=https://once-upon-a-time-beta.vercel.app/>
+        배포 서버
+    </a>
+</div>
+</body>
+</html>

--- a/src/test/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookServiceIntegrationTest.java
+++ b/src/test/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookServiceIntegrationTest.java
@@ -1,0 +1,148 @@
+package pproject.once_upon_a_time.domain.audiobook.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
+import pproject.once_upon_a_time.domain.audiobook.domain.AudioBook;
+import pproject.once_upon_a_time.domain.audiobook.repository.AudioBookRepository;
+import pproject.once_upon_a_time.domain.character.domain.Character;
+import pproject.once_upon_a_time.domain.character.repository.CharacterRepository;
+import pproject.once_upon_a_time.domain.member.domain.Member;
+import pproject.once_upon_a_time.domain.member.repository.MemberRepository;
+import pproject.once_upon_a_time.domain.script.domain.Script;
+import pproject.once_upon_a_time.domain.script.repository.ScriptRepository;
+import pproject.once_upon_a_time.domain.story.domain.GenerationStatus;
+import pproject.once_upon_a_time.domain.story.domain.Story;
+import pproject.once_upon_a_time.domain.story.repository.StoryRepository;
+import pproject.once_upon_a_time.global.common.MemberRole;
+import pproject.once_upon_a_time.global.exception.CustomException;
+import pproject.once_upon_a_time.global.exception.ErrorCode;
+import pproject.once_upon_a_time.infrastructure.PythonAudioBookRunner;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.show-sql=false",
+        "python.audiobook-path=content/audio_mock.py",
+        "ai.python-path=python3",
+        "python.timeout-seconds=30"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class AudioBookServiceIntegrationTest {
+
+    @Autowired
+    private AudioBookService audioBookService;
+
+    @Autowired
+    private AudioBookRepository audioBookRepository;
+
+    @Autowired
+    private StoryRepository storyRepository;
+
+    @Autowired
+    private CharacterRepository characterRepository;
+
+    @Autowired
+    private ScriptRepository scriptRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @SpyBean
+    private PythonAudioBookRunner pythonAudioBookRunner;
+
+    @Test
+    void makeAudioBook_savesAudioBookWithParsedResult() {
+        Member member = memberRepository.save(createMember("kakao-1", "nick1"));
+        Story story = storyRepository.save(createStory(member, "테스트 동화"));
+        Character character = characterRepository.save(createCharacter("W0208_사서"));
+        saveScripts(story, List.of("첫 문장", "두 번째 문장", "세 번째 문장"));
+
+        AudioBook audioBook = audioBookService.makeAudioBook(story.getId(), character.getId(), member);
+
+        assertThat(audioBookRepository.count()).isEqualTo(1);
+        assertThat(audioBook.getAudioUrl()).startsWith("https://mock.storage.local/audiobooks/");
+        assertThat(audioBook.getDuration()).isEqualTo(Math.round(3 * 3.0));
+        assertThat(audioBook.getMember().getId()).isEqualTo(member.getId());
+        verify(pythonAudioBookRunner, times(1)).run(any());
+    }
+
+    @Test
+    void makeAudioBook_throwsWhenNoScripts() {
+        Member member = memberRepository.save(createMember("kakao-2", "nick2"));
+        Story story = storyRepository.save(createStory(member, "스크립트 없음 동화"));
+        Character character = characterRepository.save(createCharacter("W0208_사서"));
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> audioBookService.makeAudioBook(story.getId(), character.getId(), member));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT);
+        assertThat(audioBookRepository.count()).isZero();
+        verify(pythonAudioBookRunner, times(0)).run(any());
+    }
+
+    private Member createMember(String kakaoUserId, String nickname) {
+        return Member.builder()
+                .kakaoUserId(kakaoUserId)
+                .name("name-" + nickname)
+                .nickname(nickname)
+                .role(MemberRole.USER)
+                .build();
+    }
+
+    private Story createStory(Member member, String title) {
+        return Story.builder()
+                .member(member)
+                .version("v1")
+                .modelType("model")
+                .totalSegments(0)
+                .title(title)
+                .theme("theme")
+                .vibe("vibe")
+                .originalPrompt("prompt")
+                .targetAge("age")
+                .summary("summary")
+                .content("content")
+                .generationStatus(GenerationStatus.COMPLETED)
+                .thumbnailUrl("thumb")
+                .completedAt(LocalDateTime.now())
+                .keywords(List.of("k1", "k2"))
+                .build();
+    }
+
+    private Character createCharacter(String name) {
+        return Character.builder()
+                .characterName(name)
+                .voiceSampleUrl("https://sample/voice.wav")
+                .build();
+    }
+
+    private void saveScripts(Story story, List<String> texts) {
+        for (int i = 0; i < texts.size(); i++) {
+            scriptRepository.save(
+                    Script.builder()
+                            .story(story)
+                            .seq(i + 1)
+                            .role("narrator")
+                            .text(texts.get(i))
+                            .emotion(null)
+                            .audioFilePath(null)
+                            .build()
+            );
+        }
+    }
+}

--- a/src/test/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookServiceIntegrationTest.java
+++ b/src/test/java/pproject/once_upon_a_time/domain/audiobook/service/AudioBookServiceIntegrationTest.java
@@ -76,7 +76,7 @@ class AudioBookServiceIntegrationTest {
 
         assertThat(audioBookRepository.count()).isEqualTo(1);
         assertThat(audioBook.getAudioUrl()).startsWith("https://mock.storage.local/audiobooks/");
-        assertThat(audioBook.getDuration()).isEqualTo(Math.round(3 * 3.0));
+        assertThat(audioBook.getDuration()).isEqualTo(3 * 3.14);
         assertThat(audioBook.getMember().getId()).isEqualTo(member.getId());
         verify(pythonAudioBookRunner, times(1)).run(any());
     }

--- a/src/test/java/pproject/once_upon_a_time/domain/story/service/StoryThumbnailServiceTest.java
+++ b/src/test/java/pproject/once_upon_a_time/domain/story/service/StoryThumbnailServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import pproject.once_upon_a_time.domain.member.domain.Member;
 import pproject.once_upon_a_time.domain.story.domain.GenerationStatus;
 import pproject.once_upon_a_time.domain.story.domain.Story;
@@ -115,8 +116,7 @@ class StoryThumbnailServiceTest {
     }
 
     private Story createStory(Member member, GenerationStatus status, String thumbnailUrl) {
-        return Story.builder()
-                .id(1L)
+        Story story = Story.builder()
                 .member(member)
                 .title("title")
                 .content("content")
@@ -124,5 +124,7 @@ class StoryThumbnailServiceTest {
                 .generationStatus(status)
                 .thumbnailUrl(thumbnailUrl)
                 .build();
+        ReflectionTestUtils.setField(story, "id", 1L);
+        return story;
     }
 }


### PR DESCRIPTION
## 🚀 Related Issue
- #49

## 📄 Description
• 오디오북 생성
  - 오디오북 생성 API(POST /api/v1/audiobook/make) 추가: 스토리/캐릭터/멤버로 AudioBook 생성, 대본 조회 후 파이썬 모듈 호출.
  - 파이썬 실행 러너 추가: stdin JSON → stdout JSON 파싱, 타임아웃/에러 처리, duration 반올림 저장.
  - 모의 파이썬 스크립트 추가: 동일 입출력 규격으로 로컬·테스트에서 child process 호출 검증.

• 오디오북 duration 실수 변경
  - AudioBook 엔티티의 duration을 Double로 변경해 파이썬에서 내려오는 소수 초 길이를 그대로 저장하도록 수정했습니다. 서비스 레이어도 러너 결과의 실수값을 바로 저장하게 조정
    했습니다.
  - 오디오북/플레이백 관련 응답 DTO(AudioBookMakeResponse, AudioBookResponseDto, PlaybackInfoResponse)를 소수 초를 담도록 업데이트했고, 진행률 계산 로직(PlaybackService/
    PlaybackFlushScheduler)도 Double 기반 계산으로 보정했습니다.
  - 통합 테스트 기대값을 소수 초 기준(모의 파이썬은 segments * 3.14 초)으로 맞췄습니다.
  - DB는 audio_books.duration 컬럼을 DOUBLE로 마이그레이션해야 합니다. (예: ALTER TABLE audio_books MODIFY COLUMN duration DOUBLE NOT NULL;)

  추가로, 파이썬 모의 스크립트 duration 정책을 소수 포함(3.14초 per segment)으로 변경했습니다.

## ✅ Test Checklist
- [ ] 테스트 코드를 작성하셨나요?
- [ ] 직접 Postman이나 DB를 통해 확인해 보셨나요?

## 📸 Screenshots
1. 오디오북 생성
<img width="1420" height="1302" alt="image" src="https://github.com/user-attachments/assets/c3651887-f002-49ed-966b-5fb9624cc46e" />

2. 오디오북 재생
<img width="1416" height="988" alt="image" src="https://github.com/user-attachments/assets/d26de9bf-a45b-4f9f-b138-32475683d827" />
<img width="1417" height="1321" alt="image" src="https://github.com/user-attachments/assets/d12a7aea-b1ce-4388-bb8b-1ec20c1c9690" />
<img width="1420" height="1048" alt="image" src="https://github.com/user-attachments/assets/87912b64-9875-4fc4-8fa2-59a1a707aedb" />
<img width="1419" height="1333" alt="image" src="https://github.com/user-attachments/assets/3b81347d-f5e4-4024-b7be-3c421c25a870" />
<img width="671" height="113" alt="image" src="https://github.com/user-attachments/assets/5b1e1b3a-ad7c-4709-8f2e-3bc63ea18dcb" />
두 번째 필드 확인