### PR TITLE
bug: 로그인한 사용자의 동화만 뜨도록 수정

### DIFF
--- a/src/main/java/pproject/once_upon_a_time/domain/story/controller/StoryController.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/controller/StoryController.java
@@ -39,8 +39,9 @@ public class StoryController {
 
     @GetMapping
     public ResponseEntity<ApiResult<List<StoryListResponseDto>>> getStoryList(
-            @RequestParam(required = false) String keyword) {
-        return ResponseEntity.ok(ApiResult.ok(storyService.getStoryList(keyword)));
+            @RequestParam(required = false) String keyword,
+            @Parameter(hidden = true) @LoginUser Member member) {
+        return ResponseEntity.ok(ApiResult.ok(storyService.getStoryList(keyword, member.getId())));
     }
 
     @GetMapping("/{storyId}")

--- a/src/main/java/pproject/once_upon_a_time/domain/story/repository/StoryRepository.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/repository/StoryRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
     List<Story> findByTitleContainingIgnoreCase(String title);
+    List<Story> findByMemberId(Long memberId);
+    List<Story> findByMemberIdAndTitleContainingIgnoreCase(Long memberId, String title);
 }

--- a/src/main/java/pproject/once_upon_a_time/domain/story/service/StoryService.java
+++ b/src/main/java/pproject/once_upon_a_time/domain/story/service/StoryService.java
@@ -62,12 +62,12 @@ public class StoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<StoryListResponseDto> getStoryList(String keyword) {
+    public List<StoryListResponseDto> getStoryList(String keyword, Long memberId) {
         List<Story> stories;
         if (keyword == null || keyword.isBlank()) {
-            stories = storyRepository.findAll();
+            stories = storyRepository.findByMemberId(memberId);
         } else {
-            stories = storyRepository.findByTitleContainingIgnoreCase(keyword);
+            stories = storyRepository.findByMemberIdAndTitleContainingIgnoreCase(memberId, keyword);
         }
         return stories.stream()
             .map(StoryListResponseDto::new)

--- a/src/main/java/pproject/once_upon_a_time/infrastructure/PythonAudioBookRunner.java
+++ b/src/main/java/pproject/once_upon_a_time/infrastructure/PythonAudioBookRunner.java
@@ -126,12 +126,7 @@ public class PythonAudioBookRunner {
             throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력이 비어 있습니다.");
         }
 
-        JsonNode root;
-        try {
-            root = objectMapper.readTree(stdout);
-        } catch (JsonProcessingException e) {
-            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력 파싱 실패: " + e.getMessage());
-        }
+        JsonNode root = parseToJsonNode(stdout);
 
         boolean success = root.path("success").asBoolean(false);
         if (!success) {
@@ -170,5 +165,55 @@ public class PythonAudioBookRunner {
         public int durationSecondsRounded() {
             return (int) Math.round(durationSeconds);
         }
+    }
+
+    private JsonNode parseToJsonNode(String stdout) {
+        try {
+            return objectMapper.readTree(stdout);
+        } catch (JsonProcessingException primary) {
+            log.error("RAW PYTHON OUTPUT (parse failure): {}", stdout);
+            String extracted = extractJsonSegment(stdout);
+            try {
+                return objectMapper.readTree(extracted);
+            } catch (JsonProcessingException secondary) {
+                throw new CustomException(
+                        ErrorCode.PYTHON_PROCESS_FAILED,
+                        "파이썬 출력 파싱 실패: " + secondary.getMessage()
+                );
+            }
+        }
+    }
+
+    /**
+     * stdout에 로그가 섞여 있을 때 마지막 JSON 블록을 찾아낸다.
+     * (AiProcessService.extractJsonWrapper와 동일한 아이디어)
+     */
+    private String extractJsonSegment(String output) {
+        if (output == null || output.isBlank()) {
+            throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력에서 JSON을 찾지 못했습니다.");
+        }
+
+        int successIndex = output.lastIndexOf("\"success\"");
+        if (successIndex != -1) {
+            int start = output.lastIndexOf("{", successIndex);
+            int end = output.lastIndexOf("}");
+            if (start != -1 && end != -1 && start < end) {
+                return output.substring(start, end + 1);
+            }
+        }
+
+        int braceStart = output.lastIndexOf("{");
+        int braceEnd = output.lastIndexOf("}");
+        if (braceStart != -1 && braceEnd != -1 && braceStart < braceEnd) {
+            return output.substring(braceStart, braceEnd + 1);
+        }
+
+        int arrayStart = output.indexOf("[");
+        int arrayEnd = output.lastIndexOf("]");
+        if (arrayStart != -1 && arrayEnd != -1 && arrayStart < arrayEnd) {
+            return output.substring(arrayStart, arrayEnd + 1);
+        }
+
+        throw new CustomException(ErrorCode.PYTHON_PROCESS_FAILED, "파이썬 출력에서 JSON을 찾지 못했습니다.");
     }
 }


### PR DESCRIPTION


## 🚀 Related Issue
- #81

## 📄 Description
• - 스토리 목록 조회 시 로그인 회원을 주입받아 memberId로 필터링하도록 변경했어요: StoryController.getStoryList가 @LoginUser Member를 받아 storyService.getStoryList(keyword, member.getId()) 호출하도록 수정 (src/
    main/java/pproject/once_upon_a_time/domain/story/controller/StoryController.java:37-45).
  - 서비스 레이어에서 회원 기준으로만 조회하도록 쿼리 로직 변경 (src/main/java/pproject/once_upon_a_time/domain/story/service/StoryService.java:62-76).
  - 리포지토리에 회원별 조회 메서드 추가 (findByMemberId, findByMemberIdAndTitleContainingIgnoreCase) (src/main/java/pproject/once_upon_a_time/domain/story/repository/StoryRepository.java:7-11).
  - 관리자 전체 조회 API는 그대로 유지했습니다.


## 📸 Screenshots
<img width="1417" height="917" alt="image" src="https://github.com/user-attachments/assets/346cc227-33a9-467e-8d04-85033bbeccf2" />
<img width="1039" height="141" alt="image" src="https://github.com/user-attachments/assets/081b63af-586d-46e7-ad09-80524b91dfa6" />
